### PR TITLE
fix linux switcher incorrectly exiting

### DIFF
--- a/pack-mode-switcher.sh
+++ b/pack-mode-switcher.sh
@@ -45,8 +45,6 @@ case $MODE in
     # Only copy server.properties if it exists.
     if [ -f "server.properties" ]; then
         mv "${TARGET}/server.properties" ./
-    else
-        rm "${TARGET}/server.properties"
     fi
 
     # Update Mode
@@ -59,8 +57,6 @@ case $MODE in
 
     if [ -f "server.properties" ]; then
         mv "${TARGET}/server.properties" ./
-    else
-        rm "${TARGET}/server.properties"
     fi
 
     # Update Mode


### PR DESCRIPTION
if `server.properties` is not present in the minecraft directory, it will try to delete it, which will fail and exit the script due to `set -e`